### PR TITLE
add freetype dependency

### DIFF
--- a/Formula/hhvm.rb
+++ b/Formula/hhvm.rb
@@ -14,6 +14,7 @@ class Hhvm < Formula
   depends_on 'pkg-config' => :build
 
   #Standard packages
+  depends_on 'freetype'
   depends_on 'gettext'
   depends_on 'mcrypt'
   depends_on 'glog'


### PR DESCRIPTION
This dependency is already installed if users install PHP through homebrew, but for users that did not do this, it will look at the outdated OSX headers causing build failures.

See https://github.com/facebook/hhvm/issues/1580
