### PR TITLE
Introduce CAVEATS section for tricky install situations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ HHVM requires MySQL to compile, by default will use `mysql` formula, but
 you can use `--with-mariadb` or `--with-percona-server` to compile with other
 mysql alternatives.
 
+Caveats
+-------
+
+If you have XQuartz (X11) installed, you have to temporarily remove a symbolic link at '/usr/X11R6' in order to successfully install HHVM.
+
+You can use the following command:
+```sh
+sudo rm /usr/X11R6
+```
+
+It's the root-owned file so your login password will be asked.
+
+After the install, you could return it with the command:
+```sh
+sudo ln -s /opt/X11 /usr/X11R6
+```
+
+For full reference, please see the issue [#28](https://github.com/mcuadros/homebrew-hhvm/issues/28).
+
 License
 -------
 


### PR DESCRIPTION
Hi!
I propose to introduce a section in README with a collection of possible tricky install situations.

As compilation of HHVM takes a few hours on the sufficiently weak computer, we should warn a user about possible problems which he may face.

I think the first situation should be XQuartz bug which is mentioned in #28 and #11. There are also a lot of people with the same problem in https://github.com/facebook/hhvm/issues/1580.

X11 is commonly used across developers so the repo have to solve the problem completely or warn the user at least.

The unlink and then link procedure seems OK for a quick fix before someone doesn't resolve the issue - sadly, #23 didn't help.

What do you think?
