### PR TITLE
Add dependency on libssh2

### DIFF
--- a/Formula/hhvm.rb
+++ b/Formula/hhvm.rb
@@ -31,6 +31,7 @@ class Hhvm < Formula
   depends_on 'imagemagick'
   depends_on 'binutils'
   depends_on 'ncurses'
+  depends_on 'libssh2'
   depends_on 'curl'
   depends_on 'imap-uw'
   depends_on 'gcc48'


### PR DESCRIPTION
Fixes an error when running `hhvm --help`:

```
dyld: Library not loaded: /usr/local/lib/libssh2.1.dylib
  Referenced from: /usr/local/opt/curl/lib/libcurl.4.dylib
  Reason: image not found
```
